### PR TITLE
Use <img /> to display external images

### DIFF
--- a/components/tenant/logo/logo.tsx
+++ b/components/tenant/logo/logo.tsx
@@ -27,5 +27,9 @@ export default function Logo({ name, url, width, height, className }: Props) {
     );
   }
 
-  return <Image src={url} alt={formattedName} className={cn("rounded", className)} height={height} width={width} />;
+  // These images could come from any source, <Image /> would need additional set up per external resource
+  // Just use <img /> for now.
+  // https://nextjs.org/docs/pages/api-reference/components/image#remotepatterns
+  // eslint-disable-next-line @next/next/no-img-element
+  return <img src={url} alt={formattedName} className={cn("rounded", className)} height={height} width={width} />;
 }


### PR DESCRIPTION
NextJS's `<Image />` element has restrictions on external images.

https://nextjs.org/docs/pages/api-reference/components/image#remotepatterns

We can add additional support to set remote images, but for now using `<img />` is simpler.