### PR TITLE
Settings & UI Improvements

### DIFF
--- a/app/(auth)/layout.tsx
+++ b/app/(auth)/layout.tsx
@@ -14,9 +14,9 @@ const inter = Inter({ subsets: ["latin"] });
 
 export default function Layout({ children }: Readonly<{ children: React.ReactNode }>) {
   return (
-    <div className="min-h-screen w-full flex flex-col items-center bg-white">
-      <div className="flex-1 w-full flex flex-col items-center justify-center overflow-auto">
-        <div className="w-full max-w-[717px] px-4 flex flex-col items-center justify-center">
+    <div className="h-screen w-full flex flex-col items-center bg-white overflow-hidden">
+      <div className="flex-1 w-full overflow-y-auto">
+        <div className="w-full max-w-[717px] px-4 mx-auto h-full flex flex-col items-center justify-center">
           <div className="hidden md:flex items-center mb-16">
             <div className="max-h-[64px] max-w-[64px] avatar mr-3" />
             <h1 className={cn(inter_tight.className, "text-[75px] font-bold")}>{settings.APP_NAME}</h1>
@@ -24,7 +24,7 @@ export default function Layout({ children }: Readonly<{ children: React.ReactNod
           <div className="flex flex-col items-center">{children}</div>
         </div>
       </div>
-      <div className="h-20 w-full bg-[#27272A] flex items-center justify-center">
+      <div className="h-20 shrink-0 w-full bg-[#27272A] flex items-center justify-center">
         <div className={`mr-2.5 text-md text-[#FEFEFE] ${inter.className}`}>Powered by</div>
         <div>
           <a href="https://ragie.ai/?utm_source=oss-chatbot">

--- a/app/(main)/o/[slug]/layout.tsx
+++ b/app/(main)/o/[slug]/layout.tsx
@@ -18,15 +18,10 @@ export default async function MainLayout({ children, params }: Props) {
   const user = await getUserById(session.user.id);
 
   return (
-    <div className="min-h-screen w-full flex flex-col items-center bg-white">
-      <Header
-        isAnonymous={user.isAnonymous}
-        currentProfileId={profile.id}
-        tenant={tenant}
-        name={session.user.name}
-      />
-      <main className="flex-1 w-full flex justify-center overflow-auto">
-        <div className="w-full max-w-[717px] lg:max-w-full px-4 flex flex-col items-center justify-center">
+    <div className="h-screen w-full flex flex-col items-center bg-white overflow-hidden">
+      <Header isAnonymous={user.isAnonymous} currentProfileId={profile.id} tenant={tenant} name={session.user.name} />
+      <main className="flex-1 w-full overflow-y-auto">
+        <div className="w-full max-w-[717px] lg:max-w-full px-4 mx-auto h-full flex flex-col items-center justify-center">
           {children}
         </div>
       </main>
@@ -34,7 +29,7 @@ export default async function MainLayout({ children, params }: Props) {
         <Footer tenant={tenant} className="h-[80px] shrink-0 w-full bg-[#27272A] flex items-center justify-center" />
       )}
       {profile.role == "guest" && (
-        <div className="h-20 w-full bg-[#27272A] flex items-center justify-center">
+        <div className="h-20 shrink-0 w-full bg-[#27272A] flex items-center justify-center">
           <div className={`mr-2.5 text-md text-[#FEFEFE]`}>Powered by</div>
           <div>
             <a href="https://ragie.ai/?utm_source=oss-chatbot">

--- a/app/(main)/o/[slug]/settings/general-settings.tsx
+++ b/app/(main)/o/[slug]/settings/general-settings.tsx
@@ -66,27 +66,62 @@ type TextAreaFieldProps = {
   form: UseFormReturn<z.infer<typeof formSchema>, any, undefined>;
   help?: React.ReactNode;
   className?: string;
+  hasDefault?: boolean;
 };
 
-const TextAreaField = ({ form, name, label, className, help }: TextAreaFieldProps) => (
-  <FormField
-    control={form.control}
-    name={name}
-    render={({ field }) => (
-      <FormItem className={cn("flex flex-col", className)}>
-        <FormLabel className="font-semibold text-[16px] mb-3 flex items-center gap-2">
-          {label} {help}
-        </FormLabel>
-        <FormControl>
-          <div className="rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-sm transition-colors placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm">
-            <AutosizeTextarea className="pt-1.5" minHeight={80} {...field} />
-          </div>
-        </FormControl>
-        <FormMessage />
-      </FormItem>
-    )}
-  />
-);
+const TextAreaField = ({ form, name, label, className, help, hasDefault }: TextAreaFieldProps) => {
+  const getDefaultValue = () => {
+    switch (name) {
+      case "systemPrompt":
+        return DEFAULT_SYSTEM_PROMPT;
+      case "groundingPrompt":
+        return DEFAULT_GROUNDING_PROMPT;
+      case "welcomeMessage":
+        return DEFAULT_WELCOME_MESSAGE;
+      default:
+        return "";
+    }
+  };
+
+  const handleReset = () => {
+    form.setValue(name, getDefaultValue(), {
+      shouldDirty: true,
+      shouldTouch: true,
+      shouldValidate: true,
+    });
+  };
+
+  return (
+    <FormField
+      control={form.control}
+      name={name}
+      render={({ field }) => (
+        <FormItem className={cn("flex flex-col", className)}>
+          <FormLabel className="font-semibold text-[16px] mb-3 flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              {label} {help}
+            </div>
+            {hasDefault && (
+              <button
+                type="button"
+                onClick={handleReset}
+                className="text-sm text-[#D946EF] hover:text-foreground transition-colors"
+              >
+                Reset
+              </button>
+            )}
+          </FormLabel>
+          <FormControl>
+            <div className="rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-sm transition-colors placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm">
+              <AutosizeTextarea className="pt-1.5" minHeight={80} {...field} />
+            </div>
+          </FormControl>
+          <FormMessage />
+        </FormItem>
+      )}
+    />
+  );
+};
 
 type Props = {
   tenant: typeof schema.tenants.$inferSelect;
@@ -182,6 +217,17 @@ export default function GeneralSettings({ tenant, canUploadLogo }: Props) {
       <Form {...form}>
         <form onSubmit={form.handleSubmit(onSubmit)}>
           <div>
+            <TextAreaField
+              form={form}
+              name="welcomeMessage"
+              label="Welcome Message"
+              help={<HelpWelcomeMessageDialog />}
+              className="mt-8 mb-4"
+              hasDefault={true}
+            />
+
+            <hr className="w-full my-8" />
+
             <h3 className="font-semibold text-[16px]">Example questions to help your users get started</h3>
 
             <QuestionField form={form} name="question1" label="Question 1" />
@@ -192,17 +238,10 @@ export default function GeneralSettings({ tenant, canUploadLogo }: Props) {
 
             <TextAreaField
               form={form}
-              name="welcomeMessage"
-              label="Welcome Message"
-              help={<HelpWelcomeMessageDialog />}
-              className="mt-8 mb-4"
-            />
-
-            <TextAreaField
-              form={form}
               name="groundingPrompt"
               label="Grounding Prompt"
               help={<HelpGroundingPromptDialog />}
+              hasDefault={true}
             />
 
             <TextAreaField
@@ -210,7 +249,8 @@ export default function GeneralSettings({ tenant, canUploadLogo }: Props) {
               name="systemPrompt"
               label="System Prompt"
               help={<HelpSystemPromptDialog />}
-              className="mt-8"
+              className="mt-8 mb-4"
+              hasDefault={true}
             />
           </div>
         </form>

--- a/app/api/tenants/check-slug/route.ts
+++ b/app/api/tenants/check-slug/route.ts
@@ -1,0 +1,34 @@
+import { and, eq, not } from "drizzle-orm";
+import { NextResponse } from "next/server";
+import { z } from "zod";
+
+import db from "@/lib/server/db";
+import { tenants } from "@/lib/server/db/schema";
+
+const checkSlugSchema = z.object({
+  slug: z.string().min(1),
+  tenantId: z.string().optional(),
+});
+
+export async function POST(req: Request) {
+  try {
+    const body = await req.json();
+    const { slug, tenantId } = checkSlugSchema.parse(body);
+
+    // If tenantId is provided, exclude that tenant from the check
+    // This allows us to check if the slug is unique among other tenants
+    const query = tenantId ? and(eq(tenants.slug, slug), not(eq(tenants.id, tenantId))) : eq(tenants.slug, slug);
+
+    const existingTenant = await db.select().from(tenants).where(query).limit(1);
+
+    return NextResponse.json({
+      available: existingTenant.length === 0,
+    });
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json({ error: "Invalid request body", details: error.errors }, { status: 400 });
+    }
+
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/app/api/tenants/check-slug/route.ts
+++ b/app/api/tenants/check-slug/route.ts
@@ -10,14 +10,19 @@ const checkSlugSchema = z.object({
   tenantId: z.string().optional(),
 });
 
+// returns available: boolean
+// true if slug does not exist in any tenant besides the tenantId passed in
+
 export async function POST(req: Request) {
   try {
     const body = await req.json();
-    const { slug, tenantId } = checkSlugSchema.parse(body);
+    const { slug, tenantId: tenantIdToExclude } = checkSlugSchema.parse(body);
 
     // If tenantId is provided, exclude that tenant from the check
     // This allows us to check if the slug is unique among other tenants
-    const query = tenantId ? and(eq(tenants.slug, slug), not(eq(tenants.id, tenantId))) : eq(tenants.slug, slug);
+    const query = tenantIdToExclude
+      ? and(eq(tenants.slug, slug), not(eq(tenants.id, tenantIdToExclude)))
+      : eq(tenants.slug, slug);
 
     const existingTenant = await db.select().from(tenants).where(query).limit(1);
 

--- a/components/chatbot/assistant-message.tsx
+++ b/components/chatbot/assistant-message.tsx
@@ -60,7 +60,11 @@ export default function AssistantMessage({
         <Logo name={name} url={logoUrl} width={40} height={40} className="avatar text-[13px] h-[40px] w-[40px]" />
       </div>
       <div className="self-start mb-6 rounded-md ml-7">
-        {content?.length ? <Markdown className="markdown">{content}</Markdown> : <div className="dot-pulse mt-1.5" />}
+        {content?.length ? (
+          <Markdown className="markdown mt-[10px]">{content}</Markdown>
+        ) : (
+          <div className="dot-pulse mt-[14px]" />
+        )}
         <div className="flex flex-wrap mt-4">
           {dedupedSources.map((source, i) => (
             <Citation key={i} source={source} onClick={() => onSelectedDocumentId(source.documentId)} />

--- a/components/chatbot/assistant-message.tsx
+++ b/components/chatbot/assistant-message.tsx
@@ -35,9 +35,18 @@ interface Props {
   sources: SourceMetadata[];
   onSelectedDocumentId: (id: string) => void;
   model: LLMModel;
+  isGenerating?: boolean;
 }
 
-export default function AssistantMessage({ name, logoUrl, content, sources, onSelectedDocumentId, model }: Props) {
+export default function AssistantMessage({
+  name,
+  logoUrl,
+  content,
+  sources,
+  onSelectedDocumentId,
+  model,
+  isGenerating,
+}: Props) {
   const dedupe = sources.reduce<Record<string, SourceMetadata>>((acc, v) => {
     acc[v.documentId] = v;
     return acc;
@@ -57,7 +66,9 @@ export default function AssistantMessage({ name, logoUrl, content, sources, onSe
             <Citation key={i} source={source} onClick={() => onSelectedDocumentId(source.documentId)} />
           ))}
         </div>
-        <div className="text-xs text-muted-foreground">Generated with {LLM_DISPLAY_NAMES[model]}</div>
+        <div className="text-xs text-muted-foreground">
+          {isGenerating ? `Generating with ${LLM_DISPLAY_NAMES[model]}` : `Generated with ${LLM_DISPLAY_NAMES[model]}`}
+        </div>
       </div>
     </div>
   );

--- a/components/chatbot/chat-input.tsx
+++ b/components/chatbot/chat-input.tsx
@@ -26,11 +26,13 @@ interface ChatInputProps {
 const useIsDesktop = () => {
   // Whether to display model popover to the right of settings or on top
   const [isDesktop, setIsDesktop] = useState(false); // Start with false for mobile-first approach
+  const [mounted, setMounted] = useState(false); // Whether the component has mounted
 
   useEffect(() => {
-    // Only run on client-side
+    // Only run on the client
+    setMounted(true);
     const checkIsDesktop = () => {
-      setIsDesktop(window.innerWidth >= 640); // sm breakpoint
+      setIsDesktop(window.innerWidth >= 640);
     };
 
     // Initial check
@@ -43,6 +45,8 @@ const useIsDesktop = () => {
     return () => window.removeEventListener("resize", checkIsDesktop);
   }, []);
 
+  // Return false during SSR and initial client render
+  if (!mounted) return false;
   return isDesktop;
 };
 

--- a/components/chatbot/index.tsx
+++ b/components/chatbot/index.tsx
@@ -224,6 +224,7 @@ export default function Chatbot({ tenant, conversationId, initMessage, onSelecte
                   sources={message.sources}
                   onSelectedDocumentId={onSelectedDocumentId}
                   model={message.model || selectedModel}
+                  isGenerating={false}
                 />
               </Fragment>
             ),
@@ -237,6 +238,7 @@ export default function Chatbot({ tenant, conversationId, initMessage, onSelecte
               sources={[]}
               onSelectedDocumentId={onSelectedDocumentId}
               model={pendingMessage?.model || selectedModel}
+              isGenerating={true}
             />
           )}
         </div>

--- a/components/chatbot/index.tsx
+++ b/components/chatbot/index.tsx
@@ -49,46 +49,22 @@ export default function Chatbot({ tenant, conversationId, initMessage, onSelecte
   const pendingMessageRef = useRef<null | { id: string; model: LLMModel }>(null);
   pendingMessageRef.current = pendingMessage;
   const { initialModel } = useGlobalState();
-  const [selectedModel, setSelectedModel] = useState<LLMModel>(() => {
-    if (typeof window !== "undefined") {
-      const saved = localStorage.getItem("chatSettings");
-      if (saved) {
-        const settings = JSON.parse(saved);
-        return settings.selectedModel ?? initialModel;
-      }
+  const [selectedModel, setSelectedModel] = useState<LLMModel>(initialModel);
+  const [isBreadth, setIsBreadth] = useState(false);
+  const [rerankEnabled, setRerankEnabled] = useState(false);
+  const [prioritizeRecent, setPrioritizeRecent] = useState(false);
+
+  // Load settings from localStorage after initial render
+  useEffect(() => {
+    const saved = localStorage.getItem("chatSettings");
+    if (saved) {
+      const settings = JSON.parse(saved);
+      setSelectedModel(settings.selectedModel ?? initialModel);
+      setIsBreadth(settings.isBreadth ?? false);
+      setRerankEnabled(settings.rerankEnabled ?? false);
+      setPrioritizeRecent(settings.prioritizeRecent ?? false);
     }
-    return initialModel;
-  });
-  const [isBreadth, setIsBreadth] = useState(() => {
-    if (typeof window !== "undefined") {
-      const saved = localStorage.getItem("chatSettings");
-      if (saved) {
-        const settings = JSON.parse(saved);
-        return settings.isBreadth ?? false;
-      }
-    }
-    return false;
-  });
-  const [rerankEnabled, setRerankEnabled] = useState(() => {
-    if (typeof window !== "undefined") {
-      const saved = localStorage.getItem("chatSettings");
-      if (saved) {
-        const settings = JSON.parse(saved);
-        return settings.rerankEnabled ?? false;
-      }
-    }
-    return false;
-  });
-  const [prioritizeRecent, setPrioritizeRecent] = useState(() => {
-    if (typeof window !== "undefined") {
-      const saved = localStorage.getItem("chatSettings");
-      if (saved) {
-        const settings = JSON.parse(saved);
-        return settings.prioritizeRecent ?? false;
-      }
-    }
-    return false;
-  });
+  }, [initialModel]);
 
   // Save settings to localStorage whenever they change
   useEffect(() => {
@@ -238,7 +214,7 @@ export default function Chatbot({ tenant, conversationId, initMessage, onSelecte
               sources={[]}
               onSelectedDocumentId={onSelectedDocumentId}
               model={pendingMessage?.model || selectedModel}
-              isGenerating={true}
+              isGenerating
             />
           )}
         </div>

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -56,6 +56,8 @@ export const updateTenantSchema = z.object({
   groundingPrompt: z.string().nullable(),
   systemPrompt: z.string().nullable(),
   welcomeMessage: z.string().nullable(),
+  slug: z.string(),
+  isPublic: z.boolean(),
 });
 
 export type MemberType = "profile" | "invite";


### PR DESCRIPTION
- fix footer scrolling with whole page
- move welcome message to top of settings page
- add reset button for welcome message, system and grounding prompt
- add slug validation (new api route /api/tenants/check-slug)
- center assistant messages with logo
- add "generating with {model}" while waiting for response