### PR TITLE
Stone/data page

### DIFF
--- a/app/(main)/o/[slug]/conversation-history.tsx
+++ b/app/(main)/o/[slug]/conversation-history.tsx
@@ -185,9 +185,9 @@ export default function ConversationHistory({ className, tenant }: Props) {
               <Loader2 className="h-6 w-6 animate-spin" />
             </div>
           ) : isError ? (
-            <div className="mt-4 text-gray-500">Failed to load conversations.</div>
+            <div className="mt-4 text-gray-500 pl-3">Failed to load conversations.</div>
           ) : allConversations.length === 0 ? (
-            <div className="mt-4 text-gray-500">No chat history yet.</div>
+            <div className="mt-4 text-gray-500 pl-3">No chat history yet.</div>
           ) : (
             <div className="space-y-4">
               {/* Today's conversations */}
@@ -368,7 +368,7 @@ export default function ConversationHistory({ className, tenant }: Props) {
                 ))}
 
               {/* Load more trigger */}
-              <div ref={loadMoreRef} className="h-4">
+              <div ref={loadMoreRef}>
                 {isFetchingNextPage && (
                   <div className="flex justify-center items-center">
                     <Loader2 className="h-4 w-4 animate-spin" />

--- a/app/(main)/o/[slug]/data/connections-table.tsx
+++ b/app/(main)/o/[slug]/data/connections-table.tsx
@@ -27,8 +27,6 @@ export default function ConnectionsTable({ tenant, connections }: Props) {
     return null;
   }
 
-  //   TODO: implement cursor based pagination
-  // TODO: get pages of files from res.result.pagination.nextCursor
   const totalPages = Math.ceil(connections.length / ITEMS_PER_PAGE);
   const startIndex = (currentPage - 1) * ITEMS_PER_PAGE;
   const endIndex = startIndex + ITEMS_PER_PAGE;

--- a/app/(main)/o/[slug]/data/files-table.tsx
+++ b/app/(main)/o/[slug]/data/files-table.tsx
@@ -17,13 +17,58 @@ interface Props {
     slug: string;
   };
   initialFiles: any[];
+  nextCursor: string | null;
 }
 
-export default function FilesTable({ tenant, initialFiles }: Props) {
-  const [files, setFiles] = useState(initialFiles);
-  const [currentPage, setCurrentPage] = useState(1); // basic pagination
+export default function FilesTable({ tenant, initialFiles, nextCursor }: Props) {
+  const [allFiles, setAllFiles] = useState(initialFiles);
+  const [currentNextCursor, setCurrentNextCursor] = useState<string | null>(nextCursor);
+  const [isLoading, setIsLoading] = useState(false);
+  const [currentPage, setCurrentPage] = useState(1);
   const intervalRef = useRef<NodeJS.Timeout | null>(null);
-  const ITEMS_PER_PAGE = 12; // basic pagination
+  const ITEMS_PER_PAGE = 12;
+
+  const loadNextPage = async () => {
+    if (!currentNextCursor || isLoading) return;
+
+    setIsLoading(true);
+    try {
+      const response = await fetch(`/api/tenants/current/documents?cursor=${currentNextCursor}`, {
+        headers: { tenant: tenant.slug },
+      });
+      const data = await response.json();
+
+      if (data.documents) {
+        setAllFiles((prev) => [...prev, ...data.documents]);
+        setCurrentNextCursor(data.nextCursor);
+      }
+    } catch (error) {
+      console.error("Error loading more files:", error);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const goToNextPage = async () => {
+    // If we're on the last page and have a next cursor, load more files
+    if (currentPage * ITEMS_PER_PAGE >= allFiles.length && currentNextCursor) {
+      await loadNextPage();
+    }
+    setCurrentPage((prev) => prev + 1);
+    window.scrollTo({ top: 0, behavior: "smooth" });
+  };
+
+  const goToPreviousPage = () => {
+    if (currentPage > 1) {
+      setCurrentPage((prev) => prev - 1);
+      window.scrollTo({ top: 0, behavior: "smooth" });
+    }
+  };
+
+  // Calculate the current page's files
+  const startIndex = (currentPage - 1) * ITEMS_PER_PAGE;
+  const endIndex = startIndex + ITEMS_PER_PAGE;
+  const currentFiles = allFiles.slice(startIndex, endIndex);
 
   useEffect(() => {
     const checkFilesStatus = async () => {
@@ -34,7 +79,13 @@ export default function FilesTable({ tenant, initialFiles }: Props) {
         const data = await response.json();
 
         if (data.documents) {
-          setFiles(data.documents);
+          // Only update the status of existing files
+          setAllFiles((prev) =>
+            prev.map((file) => {
+              const updatedFile = data.documents.find((d: any) => d.id === file.id);
+              return updatedFile || file;
+            }),
+          );
 
           // Check if any files are still processing
           const hasProcessingFiles = data.documents.some(
@@ -67,84 +118,87 @@ export default function FilesTable({ tenant, initialFiles }: Props) {
     };
   }, [initialFiles, tenant.slug]);
 
-  //   TODO: implement cursor based pagination
-  // TODO: get pages of files from res.result.pagination.nextCursor
-  const totalPages = Math.ceil(files.length / ITEMS_PER_PAGE);
-  const startIndex = (currentPage - 1) * ITEMS_PER_PAGE;
-  const endIndex = startIndex + ITEMS_PER_PAGE;
-  const currentFiles = files.slice(startIndex, endIndex);
-
   return (
     <div className="h-full w-full flex flex-col">
       <div className="flex justify-between items-center mb-4">
         <div className="text-[14px] font-[500] text-[#1D1D1F] pl-1">
-          {files.length} {files.length === 1 ? "file" : "files"}
+          {allFiles.length} {allFiles.length === 1 ? "file" : "files"}
         </div>
         <div className="flex items-center gap-2">
           <button
-            onClick={() => setCurrentPage((prev) => Math.max(prev - 1, 1))}
+            onClick={goToPreviousPage}
             disabled={currentPage === 1}
             className={`p-1 rounded-md ${currentPage === 1 ? "text-gray-400 cursor-not-allowed" : "text-gray-600 hover:bg-gray-100"}`}
           >
             <ChevronLeft className="h-5 w-5" />
           </button>
           <button
-            onClick={() => setCurrentPage((prev) => Math.min(prev + 1, totalPages))}
-            disabled={currentPage === totalPages}
-            className={`p-1 rounded-md ${currentPage === totalPages ? "text-gray-400 cursor-not-allowed" : "text-gray-600 hover:bg-gray-100"}`}
+            onClick={goToNextPage}
+            disabled={!currentNextCursor && currentPage * ITEMS_PER_PAGE >= allFiles.length}
+            className={`p-1 rounded-md ${
+              !currentNextCursor && currentPage * ITEMS_PER_PAGE >= allFiles.length
+                ? "text-gray-400 cursor-not-allowed"
+                : "text-gray-600 hover:bg-gray-100"
+            }`}
           >
             <ChevronRight className="h-5 w-5" />
           </button>
         </div>
       </div>
       <div className="flex-1 overflow-y-auto">
-        <Table>
-          <TableHeader>
-            <TableRow>
-              <TableHead className="w-[600px]">Name</TableHead>
-              <TableHead className="w-[200px]">Connection</TableHead>
-              <TableHead className="w-[200px]">Date added</TableHead>
-              <TableHead className="w-[200px]">Date modified</TableHead>
-              <TableHead className="w-[100px]">Status</TableHead>
-            </TableRow>
-          </TableHeader>
-          <TableBody>
-            {currentFiles.map((file) => (
-              <TableRow key={file.id}>
-                <TableCell className="font-medium flex items-center">
-                  <div>{file.name}</div>
-                </TableCell>
-                <TableCell>
-                  {file.metadata.source_type ? (
-                    <div className="flex items-center gap-2">
-                      <Image
-                        src={CONNECTOR_MAP[file.metadata.source_type][1]}
-                        alt={CONNECTOR_MAP[file.metadata.source_type][0]}
-                        className="mr-1"
-                      />
-                      {CONNECTOR_MAP[file.metadata.source_type][0]}
-                    </div>
-                  ) : (
-                    "-"
-                  )}
-                </TableCell>
-                <TableCell>{formatDistanceToNow(new Date(file.createdAt), { addSuffix: true })}</TableCell>
-                <TableCell>{formatDistanceToNow(new Date(file.updatedAt), { addSuffix: true })}</TableCell>
-                <TableCell>
-                  <div className="flex items-center gap-2">
-                    {file.status !== "ready" && file.status !== "failed" && (
-                      <Loader2 className="h-4 w-4 animate-spin text-[#006EDB]" />
-                    )}
-                    {getStatusDisplayName(file.status)}
-                  </div>
-                </TableCell>
-                <TableCell className="text-right">
-                  <ManageFileMenu id={file.id} tenant={tenant} isConnectorFile={!!file.metadata?.source_type} />
-                </TableCell>
+        {isLoading ? (
+          <div className="h-full w-full flex items-center justify-center">
+            <Loader2 className="h-8 w-8 animate-spin text-[#006EDB]" />
+          </div>
+        ) : (
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead className="w-[600px]">Name</TableHead>
+                <TableHead className="w-[200px]">Connection</TableHead>
+                <TableHead className="w-[200px]">Date added</TableHead>
+                <TableHead className="w-[200px]">Date modified</TableHead>
+                <TableHead className="w-[100px]">Status</TableHead>
               </TableRow>
-            ))}
-          </TableBody>
-        </Table>
+            </TableHeader>
+            <TableBody>
+              {currentFiles.map((file) => (
+                <TableRow key={file.id}>
+                  <TableCell className="font-medium flex items-center">
+                    <div>{file.name}</div>
+                  </TableCell>
+                  <TableCell>
+                    {file.metadata.source_type ? (
+                      <div className="flex items-center gap-2">
+                        <Image
+                          src={CONNECTOR_MAP[file.metadata.source_type][1]}
+                          alt={CONNECTOR_MAP[file.metadata.source_type][0]}
+                          className="mr-1"
+                        />
+                        {CONNECTOR_MAP[file.metadata.source_type][0]}
+                      </div>
+                    ) : (
+                      "-"
+                    )}
+                  </TableCell>
+                  <TableCell>{formatDistanceToNow(new Date(file.createdAt), { addSuffix: true })}</TableCell>
+                  <TableCell>{formatDistanceToNow(new Date(file.updatedAt), { addSuffix: true })}</TableCell>
+                  <TableCell>
+                    <div className="flex items-center gap-2">
+                      {file.status !== "ready" && file.status !== "failed" && (
+                        <Loader2 className="h-4 w-4 animate-spin text-[#006EDB]" />
+                      )}
+                      {getStatusDisplayName(file.status)}
+                    </div>
+                  </TableCell>
+                  <TableCell className="text-right">
+                    <ManageFileMenu id={file.id} tenant={tenant} isConnectorFile={!!file.metadata?.source_type} />
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        )}
       </div>
     </div>
   );

--- a/app/(main)/o/[slug]/data/files-table.tsx
+++ b/app/(main)/o/[slug]/data/files-table.tsx
@@ -3,10 +3,14 @@
 import { formatDistanceToNow } from "date-fns";
 import { ChevronLeft, ChevronRight, Loader2 } from "lucide-react";
 import Image from "next/image";
+import { useRouter } from "next/navigation";
 import { useEffect, useState, useRef } from "react";
+import Dropzone from "react-dropzone";
+import { toast } from "sonner";
 
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import CONNECTOR_MAP from "@/lib/connector-map";
+import { MAX_FILE_SIZE, getDropzoneAcceptConfig, uploadFile, validateFile } from "@/lib/file-utils";
 import { getStatusDisplayName } from "@/lib/utils";
 
 import ManageFileMenu from "./manage-file-menu";
@@ -21,12 +25,14 @@ interface Props {
 }
 
 export default function FilesTable({ tenant, initialFiles, nextCursor }: Props) {
+  const router = useRouter();
   const [allFiles, setAllFiles] = useState(initialFiles);
   const [currentNextCursor, setCurrentNextCursor] = useState<string | null>(nextCursor);
   const [isLoading, setIsLoading] = useState(false);
   const [currentPage, setCurrentPage] = useState(1);
   const intervalRef = useRef<NodeJS.Timeout | null>(null);
   const ITEMS_PER_PAGE = 12;
+  const [isDragActive, setIsDragActive] = useState(false);
 
   const loadNextPage = async () => {
     if (!currentNextCursor || isLoading) return;
@@ -119,87 +125,126 @@ export default function FilesTable({ tenant, initialFiles, nextCursor }: Props) 
   }, [initialFiles, tenant.slug]);
 
   return (
-    <div className="h-full w-full flex flex-col">
-      <div className="flex justify-between items-center mb-4">
-        <div className="text-[14px] font-[500] text-[#1D1D1F] pl-1">
-          {allFiles.length} {allFiles.length === 1 ? "file" : "files"}
-        </div>
-        <div className="flex items-center gap-2">
-          <button
-            onClick={goToPreviousPage}
-            disabled={currentPage === 1}
-            className={`p-1 rounded-md ${currentPage === 1 ? "text-gray-400 cursor-not-allowed" : "text-gray-600 hover:bg-gray-100"}`}
-          >
-            <ChevronLeft className="h-5 w-5" />
-          </button>
-          <button
-            onClick={goToNextPage}
-            disabled={!currentNextCursor && currentPage * ITEMS_PER_PAGE >= allFiles.length}
-            className={`p-1 rounded-md ${
-              !currentNextCursor && currentPage * ITEMS_PER_PAGE >= allFiles.length
-                ? "text-gray-400 cursor-not-allowed"
-                : "text-gray-600 hover:bg-gray-100"
-            }`}
-          >
-            <ChevronRight className="h-5 w-5" />
-          </button>
-        </div>
-      </div>
-      <div className="flex-1 overflow-y-auto">
-        {isLoading ? (
-          <div className="h-full w-full flex items-center justify-center">
-            <Loader2 className="h-8 w-8 animate-spin text-[#006EDB]" />
+    <Dropzone
+      onDrop={async (acceptedFiles: File[]) => {
+        const uploadPromises = acceptedFiles.map(async (file) => {
+          const validation = validateFile(file);
+          if (!validation.isValid) {
+            toast.error(validation.error);
+            return;
+          }
+          const toastId = toast.loading(`Uploading ${file.name}...`);
+
+          try {
+            await uploadFile(file, tenant.slug);
+            toast.success(`Successfully uploaded ${file.name}`, {
+              id: toastId,
+            });
+            router.refresh();
+          } catch (err) {
+            toast.error(`Failed to upload ${file.name}`, {
+              id: toastId,
+            });
+          }
+        });
+
+        await Promise.all(uploadPromises);
+      }}
+      accept={getDropzoneAcceptConfig()}
+      maxSize={MAX_FILE_SIZE}
+      onDragEnter={() => setIsDragActive(true)}
+      onDragLeave={() => setIsDragActive(false)}
+      onDropAccepted={() => setIsDragActive(false)}
+      onDropRejected={() => setIsDragActive(false)}
+      noClick
+    >
+      {({ getRootProps, getInputProps }) => (
+        <div className="h-full w-full flex flex-col" {...getRootProps()}>
+          <input {...getInputProps()} />
+          <div className="flex justify-between items-center mb-4">
+            <div className="text-[14px] font-[500] text-[#1D1D1F] pl-1">
+              {allFiles.length} {allFiles.length === 1 ? "file" : "files"}
+            </div>
+            <div className="flex items-center gap-2">
+              <button
+                onClick={goToPreviousPage}
+                disabled={currentPage === 1}
+                className={`p-1 rounded-md ${currentPage === 1 ? "text-gray-400 cursor-not-allowed" : "text-gray-600 hover:bg-gray-100"}`}
+              >
+                <ChevronLeft className="h-5 w-5" />
+              </button>
+              <button
+                onClick={goToNextPage}
+                disabled={!currentNextCursor && currentPage * ITEMS_PER_PAGE >= allFiles.length}
+                className={`p-1 rounded-md ${
+                  !currentNextCursor && currentPage * ITEMS_PER_PAGE >= allFiles.length
+                    ? "text-gray-400 cursor-not-allowed"
+                    : "text-gray-600 hover:bg-gray-100"
+                }`}
+              >
+                <ChevronRight className="h-5 w-5" />
+              </button>
+            </div>
           </div>
-        ) : (
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead className="w-[600px]">Name</TableHead>
-                <TableHead className="w-[200px]">Connection</TableHead>
-                <TableHead className="w-[200px]">Date added</TableHead>
-                <TableHead className="w-[200px]">Date modified</TableHead>
-                <TableHead className="w-[100px]">Status</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {currentFiles.map((file) => (
-                <TableRow key={file.id}>
-                  <TableCell className="font-medium flex items-center">
-                    <div>{file.name}</div>
-                  </TableCell>
-                  <TableCell>
-                    {file.metadata.source_type ? (
-                      <div className="flex items-center gap-2">
-                        <Image
-                          src={CONNECTOR_MAP[file.metadata.source_type][1]}
-                          alt={CONNECTOR_MAP[file.metadata.source_type][0]}
-                          className="mr-1"
-                        />
-                        {CONNECTOR_MAP[file.metadata.source_type][0]}
-                      </div>
-                    ) : (
-                      "-"
-                    )}
-                  </TableCell>
-                  <TableCell>{formatDistanceToNow(new Date(file.createdAt), { addSuffix: true })}</TableCell>
-                  <TableCell>{formatDistanceToNow(new Date(file.updatedAt), { addSuffix: true })}</TableCell>
-                  <TableCell>
-                    <div className="flex items-center gap-2">
-                      {file.status !== "ready" && file.status !== "failed" && (
-                        <Loader2 className="h-4 w-4 animate-spin text-[#006EDB]" />
-                      )}
-                      {getStatusDisplayName(file.status)}
-                    </div>
-                  </TableCell>
-                  <TableCell className="text-right">
-                    <ManageFileMenu id={file.id} tenant={tenant} isConnectorFile={!!file.metadata?.source_type} />
-                  </TableCell>
-                </TableRow>
-              ))}
-            </TableBody>
-          </Table>
-        )}
-      </div>
-    </div>
+          <div
+            className={`flex-1 overflow-y-auto relative ${isDragActive ? "after:content-[''] after:absolute after:inset-0 after:bg-[#F0F7FF] after:border-2 after:border-[#007AFF] after:border-dashed after:rounded-lg after:pointer-events-none" : ""}`}
+          >
+            {isLoading ? (
+              <div className="h-full w-full flex items-center justify-center">
+                <Loader2 className="h-8 w-8 animate-spin text-[#006EDB]" />
+              </div>
+            ) : (
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead className="w-[600px]">Name</TableHead>
+                    <TableHead className="w-[200px]">Connection</TableHead>
+                    <TableHead className="w-[200px]">Date added</TableHead>
+                    <TableHead className="w-[200px]">Date modified</TableHead>
+                    <TableHead className="w-[100px]">Status</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {currentFiles.map((file) => (
+                    <TableRow key={file.id}>
+                      <TableCell className="font-medium flex items-center">
+                        <div>{file.name}</div>
+                      </TableCell>
+                      <TableCell>
+                        {file.metadata.source_type ? (
+                          <div className="flex items-center gap-2">
+                            <Image
+                              src={CONNECTOR_MAP[file.metadata.source_type][1]}
+                              alt={CONNECTOR_MAP[file.metadata.source_type][0]}
+                              className="mr-1"
+                            />
+                            {CONNECTOR_MAP[file.metadata.source_type][0]}
+                          </div>
+                        ) : (
+                          "-"
+                        )}
+                      </TableCell>
+                      <TableCell>{formatDistanceToNow(new Date(file.createdAt), { addSuffix: true })}</TableCell>
+                      <TableCell>{formatDistanceToNow(new Date(file.updatedAt), { addSuffix: true })}</TableCell>
+                      <TableCell>
+                        <div className="flex items-center gap-2">
+                          {file.status !== "ready" && file.status !== "failed" && (
+                            <Loader2 className="h-4 w-4 animate-spin text-[#006EDB]" />
+                          )}
+                          {getStatusDisplayName(file.status)}
+                        </div>
+                      </TableCell>
+                      <TableCell className="text-right">
+                        <ManageFileMenu id={file.id} tenant={tenant} isConnectorFile={!!file.metadata?.source_type} />
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            )}
+          </div>
+        </div>
+      )}
+    </Dropzone>
   );
 }

--- a/app/(main)/o/[slug]/data/files-table.tsx
+++ b/app/(main)/o/[slug]/data/files-table.tsx
@@ -34,6 +34,17 @@ export default function FilesTable({ tenant, initialFiles, nextCursor }: Props) 
   const ITEMS_PER_PAGE = 12;
   const [isDragActive, setIsDragActive] = useState(false);
 
+  // update the table if a file has been deleted
+  const handleFileRemoved = (fileId: string) => {
+    setAllFiles((prev) => {
+      const index = prev.findIndex((file) => file.id === fileId);
+      if (index === -1) return prev; // File not found
+      const newFiles = [...prev];
+      newFiles.splice(index, 1);
+      return newFiles;
+    });
+  };
+
   const loadNextPage = async () => {
     if (!currentNextCursor || isLoading) return;
 
@@ -235,7 +246,12 @@ export default function FilesTable({ tenant, initialFiles, nextCursor }: Props) 
                         </div>
                       </TableCell>
                       <TableCell className="text-right">
-                        <ManageFileMenu id={file.id} tenant={tenant} isConnectorFile={!!file.metadata?.source_type} />
+                        <ManageFileMenu
+                          id={file.id}
+                          tenant={tenant}
+                          isConnectorFile={!!file.metadata?.source_type}
+                          onFileRemoved={handleFileRemoved}
+                        />
                       </TableCell>
                     </TableRow>
                   ))}

--- a/app/(main)/o/[slug]/data/manage-file-menu.tsx
+++ b/app/(main)/o/[slug]/data/manage-file-menu.tsx
@@ -18,9 +18,10 @@ interface Props {
     slug: string;
   };
   isConnectorFile: boolean;
+  onFileRemoved: (fileId: string) => void;
 }
 
-export default function ManageFileMenu({ id, tenant, isConnectorFile }: Props) {
+export default function ManageFileMenu({ id, tenant, isConnectorFile, onFileRemoved }: Props) {
   const router = useRouter();
 
   async function deleteFile() {
@@ -42,6 +43,7 @@ export default function ManageFileMenu({ id, tenant, isConnectorFile }: Props) {
       toast.success("File deleted successfully", {
         id: toastId,
       });
+      onFileRemoved(id);
       router.refresh();
     } catch (error) {
       toast.error("Failed to delete file", {

--- a/app/(main)/o/[slug]/data/page.tsx
+++ b/app/(main)/o/[slug]/data/page.tsx
@@ -24,12 +24,15 @@ export default async function DataIndexPage({ params }: Props) {
   const connections = await db.select().from(schema.connections).where(eq(schema.connections.tenantId, tenant.id));
 
   let files: any[] = [];
+  let nextCursor: string | null = null;
   try {
     const { client, partition } = await getRagieClientAndPartition(tenant.id);
     const res = await client.documents.list({
       partition: partition || "",
+      pageSize: 12,
     });
     files = res.result.documents;
+    nextCursor = res.result.pagination.nextCursor || null;
   } catch (error) {
     console.error("Error fetching documents:", error);
   }
@@ -60,7 +63,7 @@ export default async function DataIndexPage({ params }: Props) {
         </TabsList>
         <TabsContent value="files" className="flex-1 overflow-hidden">
           {files.length > 0 ? (
-            <FilesTable tenant={tenant} initialFiles={files} />
+            <FilesTable tenant={tenant} initialFiles={files} nextCursor={nextCursor} />
           ) : (
             <div className="flex-grow w-full flex flex-col items-center justify-center h-[calc(100vh-400px)]">
               <FileDropzone tenant={tenant} />

--- a/app/api/tenants/current/documents/route.ts
+++ b/app/api/tenants/current/documents/route.ts
@@ -6,12 +6,21 @@ import { requireAdminContextFromRequest } from "@/lib/server/utils";
 export async function GET(request: NextRequest) {
   const { tenant } = await requireAdminContextFromRequest(request);
   const { client, partition } = await getRagieClientAndPartition(tenant.id);
+
+  // Get cursor from query params
+  const searchParams = request.nextUrl.searchParams;
+  const cursor = searchParams.get("cursor") || undefined;
+
   try {
     const res = await client.documents.list({
       partition: partition || "",
+      cursor,
     });
 
-    return NextResponse.json({ documents: res.result.documents });
+    return NextResponse.json({
+      documents: res.result.documents,
+      nextCursor: res.result.pagination.nextCursor,
+    });
   } catch (error) {
     console.error("Error fetching documents:", error);
     return NextResponse.json({ error: "Failed to fetch documents" }, { status: 500 });

--- a/components/chatbot/index.tsx
+++ b/components/chatbot/index.tsx
@@ -22,7 +22,7 @@ type SystemMessage = { content: string; role: "system" };
 type Message = AiMessage | UserMessage | SystemMessage;
 
 const UserMessage = ({ content }: { content: string }) => (
-  <div className="mb-6 rounded-md px-4 py-2 self-end bg-[#F5F5F7]">{content}</div>
+  <div className="mb-6 rounded-md px-4 py-2 self-end bg-[#F5F5F7] w-[70%]">{content}</div>
 );
 
 interface Props {


### PR DESCRIPTION
- cursor based pagination for files table
- small styling fix for conversation history
- cap user messages to 70% width of chatbot
- add drag and drop functionality over the files table
- refresh files table after a file is deleted