### PR TITLE
dont enforce partition limit for seats only plan

### DIFF
--- a/app/(pricing)/pricing/[slug]/plans/plans-page-client.tsx
+++ b/app/(pricing)/pricing/[slug]/plans/plans-page-client.tsx
@@ -56,7 +56,7 @@ function FeatureItem() {
             <td key={tierId} className="border-b py-3">
               <TierFeatureContent
                 check={false}
-                text={isEnterprise ? "Custom" : `${plan?.partitionLimit.toLocaleString()} pages`}
+                text={isEnterprise ? "Custom" : `${plan.partitionLimit!.toLocaleString()} pages`}
               />
             </td>
           );

--- a/app/(pricing)/pricing/[slug]/plans/plans-page-client.tsx
+++ b/app/(pricing)/pricing/[slug]/plans/plans-page-client.tsx
@@ -56,7 +56,7 @@ function FeatureItem() {
             <td key={tierId} className="border-b py-3">
               <TierFeatureContent
                 check={false}
-                text={isEnterprise ? "Custom" : `${plan.partitionLimit!.toLocaleString()} pages`}
+                text={isEnterprise || !plan.partitionLimit ? "Custom" : `${plan.partitionLimit.toLocaleString()} pages`}
               />
             </td>
           );

--- a/lib/orb-types.ts
+++ b/lib/orb-types.ts
@@ -35,7 +35,7 @@ export type PlanDef = {
   displayName: string;
   alternateCycleType?: PlanType;
   description: string;
-  partitionLimit: number;
+  partitionLimit: number | null;
   hasCustomPricing?: boolean;
   streamingLimit: number;
   audioLimit: number;
@@ -106,7 +106,7 @@ export const PLANS: Record<PlanType, PlanDef> = {
     price: 0,
     displayName: "Pro",
     description: "Designed for growing teams and content",
-    partitionLimit: 60000,
+    partitionLimit: null, // don't enforce partition limits if tenant brings their own api key
     streamingLimit: 1, // 1 TB
     audioLimit: 100,
     videoLimit: 100,


### PR DESCRIPTION
** partition limits will still be enforced, just not automatically set for BYO api key cases