### PR TITLE
Add Claude 4.5, handle Kimi K2 deprecation

### DIFF
--- a/app/(main)/o/[slug]/settings/models/model-settings.tsx
+++ b/app/(main)/o/[slug]/settings/models/model-settings.tsx
@@ -17,7 +17,6 @@ import {
   LLM_DISPLAY_NAMES,
   LLM_LOGO_MAP,
   LLMModel,
-  modelArraySchema,
   getEnabledModelsFromDisabled,
   modelSchema,
   NON_AGENTIC_MODELS,
@@ -25,7 +24,7 @@ import {
 import * as schema from "@/lib/server/db/schema";
 
 const formSchema = z.object({
-  disabledModels: modelArraySchema,
+  disabledModels: z.array(z.string()).nullable(),
   defaultModel: modelSchema,
   isBreadth: z.boolean().default(false),
   overrideBreadth: z.boolean().default(true),

--- a/components/agentic-retriever/agentic-response.tsx
+++ b/components/agentic-retriever/agentic-response.tsx
@@ -6,7 +6,6 @@ import {
   Brain,
   MessageSquare,
   CheckCircle,
-  XCircle,
   List,
   BookOpenCheck,
   ChevronDown,
@@ -261,8 +260,9 @@ export function EvaluatedAnswerStep({ step }: { step: Step & { type: "evaluated_
       <div className="flex mb-2">
         {step.eval_reason && (
           <span
-            className={`px-2 py-1 rounded text-xs ${step.eval_passed ? "bg-green-100 text-green-800" : "bg-red-100 text-red-800"
-              }`}
+            className={`px-2 py-1 rounded text-xs ${
+              step.eval_passed ? "bg-green-100 text-green-800" : "bg-red-100 text-red-800"
+            }`}
           >
             {step.eval_passed ? "PASSED" : "FAILED"}
           </span>

--- a/components/chatbot/assistant-message.tsx
+++ b/components/chatbot/assistant-message.tsx
@@ -22,7 +22,7 @@ function getDisplayName(model: string) {
   return "unsupported model";
 }
 
-const Citation = ({ source, onClick = () => { } }: { source: SourceMetadata; onClick?: () => void }) => {
+export const Citation = ({ source, onClick = () => {} }: { source: SourceMetadata; onClick?: () => void }) => {
   const connector = CONNECTOR_MAP[source.source_type];
   const isAudio =
     source.documentName?.toLowerCase() &&

--- a/components/chatbot/assistant-message.tsx
+++ b/components/chatbot/assistant-message.tsx
@@ -15,7 +15,14 @@ import Logo from "../tenant/logo/logo";
 
 const MAX_CITATION_LENGTH = 30;
 
-export const Citation = ({ source, onClick = () => {} }: { source: SourceMetadata; onClick?: () => void }) => {
+function getDisplayName(model: string) {
+  if (LLM_DISPLAY_NAMES[model as LLMModel]) {
+    return LLM_DISPLAY_NAMES[model as LLMModel];
+  }
+  return "unsupported model";
+}
+
+const Citation = ({ source, onClick = () => { } }: { source: SourceMetadata; onClick?: () => void }) => {
   const connector = CONNECTOR_MAP[source.source_type];
   const isAudio =
     source.documentName?.toLowerCase() &&
@@ -154,7 +161,7 @@ export default function AssistantMessage({
           ))}
         </div>
         <div className="text-xs text-muted-foreground">
-          {isGenerating ? `Generating with ${LLM_DISPLAY_NAMES[model]}` : `Generated with ${LLM_DISPLAY_NAMES[model]}`}
+          {isGenerating ? `Generating with ${getDisplayName(model)}` : `Generated with ${getDisplayName(model)}`}
         </div>
       </div>
     </div>

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -35,7 +35,7 @@ export const conversationMessagesResponseSchema = z.array(
       role: z.literal("assistant"),
       sources: z.array(z.any()).default([]),
       expanded: z.boolean().default(false),
-      model: modelSchema,
+      model: z.string(), // z.string() instead of modelSchema to allow reading unsupported legacy models
       type: z.literal("standard").optional(),
     }),
     z.object({
@@ -44,7 +44,7 @@ export const conversationMessagesResponseSchema = z.array(
       role: z.literal("assistant"),
       sources: z.array(z.any()).default([]),
       expanded: z.boolean().default(false),
-      model: modelSchema,
+      model: z.string(), // z.string() instead of modelSchema to allow reading unsupported legacy models
       type: z.literal("agentic"),
       agenticInfo: z.object({
         runId: z.string(),

--- a/lib/llm/types.ts
+++ b/lib/llm/types.ts
@@ -114,7 +114,7 @@ export const PROVIDER_CONFIG = {
       "meta-llama/llama-4-scout-17b-16e-instruct": "Llama 4 Scout",
       "openai/gpt-oss-20b": "GPT-OSS 20B",
       "openai/gpt-oss-120b": "GPT-OSS 120B",
-      "moonshotai/kimi-k2-instruct-0905": "Kimi K2 0905",
+      "moonshotai/kimi-k2-instruct-0905": "Kimi K2",
     } as const,
     modelConfigs: {
       "meta-llama/llama-4-scout-17b-16e-instruct": {

--- a/lib/llm/types.ts
+++ b/lib/llm/types.ts
@@ -75,6 +75,7 @@ export const PROVIDER_CONFIG = {
       "claude-3-5-haiku-latest",
       "claude-opus-4-20250514",
       "claude-sonnet-4-20250514",
+      "claude-sonnet-4-5-20250929",
     ] as const,
     logo: "/anthropic.svg",
     modelLogos: {
@@ -82,18 +83,21 @@ export const PROVIDER_CONFIG = {
       "claude-3-5-haiku-latest": "/anthropic.svg",
       "claude-opus-4-20250514": "/anthropic.svg",
       "claude-sonnet-4-20250514": "/anthropic.svg",
+      "claude-sonnet-4-5-20250929": "/anthropic.svg",
     } as const,
     displayNames: {
       "claude-3-7-sonnet-latest": "Claude 3.7 Sonnet",
       "claude-3-5-haiku-latest": "Claude 3.5 Haiku",
       "claude-opus-4-20250514": "Claude 4 Opus",
       "claude-sonnet-4-20250514": "Claude 4 Sonnet",
+      "claude-sonnet-4-5-20250929": "Claude 4.5 Sonnet",
     } as const,
     modelConfigs: {
       "claude-3-7-sonnet-latest": { temperature: DEFAULT_TEMPERATURE },
       "claude-3-5-haiku-latest": { temperature: DEFAULT_TEMPERATURE },
       "claude-opus-4-20250514": { temperature: DEFAULT_TEMPERATURE },
       "claude-sonnet-4-20250514": { temperature: DEFAULT_TEMPERATURE },
+      "claude-sonnet-4-5-20250929": { temperature: DEFAULT_TEMPERATURE },
     } as const,
   },
   groq: {

--- a/lib/llm/types.ts
+++ b/lib/llm/types.ts
@@ -101,20 +101,20 @@ export const PROVIDER_CONFIG = {
       "meta-llama/llama-4-scout-17b-16e-instruct",
       "openai/gpt-oss-20b",
       "openai/gpt-oss-120b",
-      "moonshotai/kimi-k2-instruct",
+      "moonshotai/kimi-k2-instruct-0905",
     ] as const,
     logo: "/meta.svg",
     modelLogos: {
       "meta-llama/llama-4-scout-17b-16e-instruct": "/meta.svg",
       "openai/gpt-oss-20b": "/openai.svg",
       "openai/gpt-oss-120b": "/openai.svg",
-      "moonshotai/kimi-k2-instruct": "/moonshot.svg",
+      "moonshotai/kimi-k2-instruct-0905": "/moonshot.svg",
     } as const,
     displayNames: {
       "meta-llama/llama-4-scout-17b-16e-instruct": "Llama 4 Scout",
       "openai/gpt-oss-20b": "GPT-OSS 20B",
       "openai/gpt-oss-120b": "GPT-OSS 120B",
-      "moonshotai/kimi-k2-instruct": "Kimi K2",
+      "moonshotai/kimi-k2-instruct-0905": "Kimi K2 0905",
     } as const,
     modelConfigs: {
       "meta-llama/llama-4-scout-17b-16e-instruct": {
@@ -123,7 +123,7 @@ export const PROVIDER_CONFIG = {
       },
       "openai/gpt-oss-20b": { temperature: DEFAULT_TEMPERATURE },
       "openai/gpt-oss-120b": { temperature: DEFAULT_TEMPERATURE },
-      "moonshotai/kimi-k2-instruct": { temperature: DEFAULT_TEMPERATURE, systemPrompt: KIMI_K2_PROMPT },
+      "moonshotai/kimi-k2-instruct-0905": { temperature: DEFAULT_TEMPERATURE, systemPrompt: KIMI_K2_PROMPT },
     } as const,
   },
 } as const;


### PR DESCRIPTION
Add new Anthropic Claude 4.5 Sonnet model
Kimi K2 is being deprecated by Groq.
1. we need to use the new version going forward, Kimi K2 0905
2. we need to handle cases where tenants previously used the only Kimi model in conversations and not blow up

https://console.groq.com/docs/model/moonshotai/kimi-k2-instruct-0905?utm_medium=email&_hsenc=p2ANqtz-8r_requFsd4PuRtimhvcfLSjyI9eQlSLD2TQhPTQznMjGysbAtuHyQYu7ZcsJhPFW4okddgt5IUoO0uRE73GeSMyMFSw&_hsmi=379826422&utm_content=379826422&utm_source=hs_automation